### PR TITLE
feat: add pre-build script to fetch and inject VS Code settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,62 +5,61 @@
     "vscode": {
       "extensions": [
         // keep-sorted start case=no
+        "adamhartford.vscode-base64",
+        "antfu.slidev",
+        "bierner.markdown-mermaid",
         "bierner.markdown-preview-github-styles",
-        "DavidAnson.vscode-markdownlint",
-        "dedsec727.jekyll-run",
+        "davidanson.vscode-markdownlint",
         "esbenp.prettier-vscode",
-        "GitHub.copilot",
-        "me-dutour-mathieu.vscode-github-actions",
-        "timonwong.shellcheck",
-        "Tyriar.sort-lines",
+        "github.copilot",
+        "github.vscode-github-actions",
+        "github.vscode-pull-request-github",
+        "hashicorp.terraform",
+        "hverlin.mise-vscode",
+        "mechatroner.rainbow-csv",
+        "pkief.material-icon-theme",
+        "redhat.vscode-yaml",
+        "streetsidesoftware.code-spell-checker",
+        "tyriar.sort-lines",
         "yzhang.markdown-all-in-one"
         // keep-sorted end
       ],
-      "settings": {
-        // keep-sorted start block=yes
-        "[json][markdown][yaml]": {
-          "editor.defaultFormatter": "esbenp.prettier-vscode"
-        },
-        "[markdown]": {
-          "editor.wordWrap": "off"
-        },
-        "editor.autoClosingQuotes": "never",
-        "editor.cursorBlinking": "smooth",
-        "editor.dragAndDrop": false,
-        "editor.hover.enabled": false,
-        "editor.parameterHints.enabled": false,
-        "editor.quickSuggestions": {
-          "other": "off"
-        },
-        "editor.rulers": [80],
-        "editor.smoothScrolling": true,
-        "editor.tabSize": 2,
-        "extensions.ignoreRecommendations": true,
-        "files.insertFinalNewline": true,
-        "files.trimFinalNewlines": true,
-        "files.trimTrailingWhitespace": true,
-        "git.autofetch": true,
-        "github.copilot.enable": {
-          "*": true,
-          "plaintext": true,
-          "markdown": true
-        }
-        // keep-sorted end
-      }
+      // Do not use the `settings` - it is populated by the `pre-build` script.
+      "settings": {}
     }
+  },
+
+  "features": {
+    // keep-sorted start
+    "ghcr.io/devcontainers-extra/features/mise:1": {},
+    "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
+    "ghcr.io/devcontainers-extra/features/starship:1": {}
+    // keep-sorted end
   },
 
   "forwardPorts": [4000],
 
   "image": "mcr.microsoft.com/devcontainers/jekyll:latest",
 
+  "initializeCommand": "bash .devcontainer/pre-build.sh",
+
   "name": "ruzickap.github.io",
+
+  "onCreateCommand": [
+    "bash",
+    "-c",
+    "echo -e 'eval \"$(mise activate bash)\"\neval \"$(starship init bash)\"' >> ~/.bashrc"
+  ],
 
   "portsAttributes": {
     "4000": {
       "label": "jekyll",
       "onAutoForward": "openPreview"
     }
-  }
+  },
+
+  "postStartCommand": "wget https://raw.githubusercontent.com/ruzickap/ansible-my_workstation/refs/heads/main/ansible/files/home/myusername/.config/Code/User/settings.json -O ~/.vscode-remote/data/Machine/settings.json",
+
+  "remoteUser": "vscode"
   // keep-sorted end
 }

--- a/.devcontainer/pre-build.sh
+++ b/.devcontainer/pre-build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+SETTINGS_URL="https://raw.githubusercontent.com/ruzickap/ansible-my_workstation/refs/heads/main/ansible/files/home/myusername/.config/Code/User/settings.json"
+DEST_FILE=".vscode/settings.json"
+
+echo "🔄 Fetching VS Code settings from ${SETTINGS_URL}..."
+mkdir -p .vscode
+curl -fsSL "${SETTINGS_URL}" -o "${DEST_FILE}"
+
+SETTINGS_JSON=$(sed 's/^ *\/\/.*//' "${DEST_FILE}" | jq -c '.')
+
+echo "🔄 Injecting settings into devcontainer.json..."
+
+sed 's/^ *\/\/.*//' .devcontainer/devcontainer.json | jq --argjson settings "${SETTINGS_JSON}" '.customizations.vscode.settings = $settings' > .devcontainer/devcontainer.temp.json &&
+  mv .devcontainer/devcontainer.temp.json .devcontainer/devcontainer.json
+
+echo "✅ Settings injected successfully."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# https://github.com/devcontainers/images/tree/main/src/jekyll/.devcontainer
 FROM ruby:3-slim AS build
 
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]


### PR DESCRIPTION
Introduce a pre-build script that fetches and injects VS Code settings into the devcontainer configuration. This streamlines the setup process by ensuring the correct settings are applied automatically.