### PR TITLE
refactor: update post_tests workflow

### DIFF
--- a/.github/workflows/post_tests.yml
+++ b/.github/workflows/post_tests.yml
@@ -75,6 +75,7 @@ jobs:
           curl https://mise.run | sh
           echo "$HOME/.local/share/mise/bin" >> "${GITHUB_PATH}"
           echo "$HOME/.local/share/mise/shims" >> "${GITHUB_PATH}"
+          mise install
 
       - name: "${{ inputs.action }} | ${{ inputs.posts }}"
         env:

--- a/.github/workflows/post_tests.yml
+++ b/.github/workflows/post_tests.yml
@@ -54,7 +54,7 @@ jobs:
       contents: read
     name: "${{ inputs.action }} | ${{ inputs.posts }}"
     concurrency:
-      group: post_tests
+      group: post_tests-${{ inputs.cluster_fqdn }}
     timeout-minutes: 100
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/post_tests.yml
+++ b/.github/workflows/post_tests.yml
@@ -7,15 +7,15 @@ on:
       posts:
         type: choice
         description: Select post
-        default: 2025-02-01-eks-auto-cert-manager-velero 2024-12-14-secure-cheap-amazon-eks-auto
+        default: 2025-02-01-eks-auto-cert-manager-velero|2024-12-14-secure-cheap-amazon-eks-auto
         options:
           - 2022-11-27-cheapest-amazon-eks
-          - 2022-12-24-amazon-eks-karpenter-tests 2022-11-27-cheapest-amazon-eks
-          # - 2023-03-08-trivy-operator-grafana 2022-11-27-cheapest-amazon-eks
-          - 2023-03-20-velero-and-cert-manager 2022-11-27-cheapest-amazon-eks
-          - 2023-04-01-secrets-store-csi-driver-reloader 2023-03-20-velero-and-cert-manager 2022-11-27-cheapest-amazon-eks
-          - 2023-04-01-secrets-store-csi-driver-reloader 2022-11-27-cheapest-amazon-eks
-          - 2023-06-06-my-favourite-krew-plugins-kubectl 2022-11-27-cheapest-amazon-eks
+          - 2022-12-24-amazon-eks-karpenter-tests|2022-11-27-cheapest-amazon-eks
+          # - 2023-03-08-trivy-operator-grafana|2022-11-27-cheapest-amazon-eks
+          - 2023-03-20-velero-and-cert-manager|2022-11-27-cheapest-amazon-eks
+          - 2023-04-01-secrets-store-csi-driver-reloader|2023-03-20-velero-and-cert-manager|2022-11-27-cheapest-amazon-eks
+          - 2023-04-01-secrets-store-csi-driver-reloader|2022-11-27-cheapest-amazon-eks
+          - 2023-06-06-my-favourite-krew-plugins-kubectl|2022-11-27-cheapest-amazon-eks
           - 2023-08-03-cilium-amazon-eks
           - 2023-09-25-secure-cheap-amazon-eks
           - 2024-04-27-exploit-vulnerability-wordpress-plugin-kali-linux-1
@@ -24,24 +24,25 @@ on:
           # - 2024-07-07-detect-a-hacker-attacks-eks-vm
           - 2024-12-12-terraform-keep-sorted
           - 2024-12-14-secure-cheap-amazon-eks-auto
-          - 2025-02-01-eks-auto-cert-manager-velero 2024-12-14-secure-cheap-amazon-eks-auto
+          - 2025-02-01-eks-auto-cert-manager-velero|2024-12-14-secure-cheap-amazon-eks-auto
       action:
         type: choice
         description: Select action
-        default: build + destroy
+        default: create
         options:
-          - build
-          - destroy
-          - build + destroy
+          - create
+          - delete
+      cluster_fqdn:
+        type: string
+        description: Cluster FQDN
+        default: k01.k8s.mylabs.dev
 
 env:
   AWS_DEFAULT_REGION: us-east-1
   AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
   GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-  CLUSTER_FQDN: k01.k8s.mylabs.dev
-  CLUSTER_NAME: k01
-  TAGS: "product_id='12345',used_for=dev,owner=petr.ruzicka@gmail.com,cluster=k01.k8s.mylabs.dev"
+  CLUSTER_FQDN: ${{ inputs.cluster_fqdn }}
 
 permissions: read-all
 
@@ -70,85 +71,13 @@ jobs:
 
       - name: "${{ inputs.action }} | ${{ inputs.posts }}"
         env:
-          GH_TOKEN: ${{ github.token }}
-          GH_ACTION: ${{ inputs.action }}
-          GH_INPUTS: ${{ inputs.posts }}
+          ACTION: ${{ inputs.action }}
+          POSTS: ${{ inputs.posts }}
         run: |
           set -euxo pipefail
 
-          export TMP_DIR="${PWD}"
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install mdq
+          curl https://mise.run | sh
+          echo "$HOME/.local/share/mise/bin" >> "${GITHUB_PATH}"
+          echo "$HOME/.local/share/mise/shims" >> "${GITHUB_PATH}"
 
-          POST_FILES_ARRAY=()
-          # shellcheck disable=SC2043
-          for POST_FILE in ${GH_INPUTS}; do
-            POST_FILES_ARRAY+=("$(find "${PWD}/_posts" -type f -name "*${POST_FILE}*.md")")
-          done
-
-          case "${GH_ACTION}" in
-            *"build"*)
-              echo "🔨 ***" "${POST_FILES_ARRAY[@]}" "| build"
-              MDQ_CODE_BLOCK='```^bash$'
-              echo "set -euxo pipefail" > "${TMP_DIR}/run.sh"
-              for (( idx=${#POST_FILES_ARRAY[@]}-1 ; idx>=0 ; idx-- )); do
-                echo "🔨 *** ${POST_FILES_ARRAY[idx]} | build"
-                mdq "${MDQ_CODE_BLOCK}" --br -o plain "${POST_FILES_ARRAY[idx]}" >> "${TMP_DIR}/run.sh"
-              done
-              ;;&
-            *"destroy"*)
-              echo "🔨 ***" "${POST_FILES_ARRAY[@]}" "| destroy"
-              MDQ_CODE_BLOCK='```^sh$'
-              echo "set -x" >> "${TMP_DIR}/run.sh"
-              if aws eks describe-cluster --name "${CLUSTER_NAME}" --query 'cluster.status' &> /dev/null; then
-                export KUBECONFIG="${TMP_DIR}/${CLUSTER_FQDN}/kubeconfig-${CLUSTER_NAME}.conf"
-                aws eks update-kubeconfig --region "${AWS_DEFAULT_REGION}" --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG}" || true
-              fi
-              mdq "${MDQ_CODE_BLOCK}" --br -o plain "${POST_FILES_ARRAY[@]}" >> "${TMP_DIR}/run.sh"
-              ;;
-            *)
-              if [[ "${GH_ACTION}" != "build" ]]; then
-                echo "❓ Unknown action: ${GH_ACTION}"
-                exit 1
-              fi
-              ;;
-          esac
-
-          if grep -Eq '(^| )eksctl ' "${TMP_DIR}/run.sh" && ! command -v eksctl &> /dev/null ; then
-            echo "📦 *** Installing eksctl"
-            brew install eksctl
-            (
-              echo "<https://${CLUSTER_FQDN}>"
-              echo '```'
-              echo "export AWS_DEFAULT_REGION=\"${AWS_DEFAULT_REGION}\""
-              # shellcheck disable=SC2028
-              echo "eval \"\$(aws sts assume-role --role-arn \"\${AWS_ROLE_TO_ASSUME}\" --role-session-name \"\$USER@\$(hostname -f)-k8s-\$(date +%s)\" --duration-seconds 36000 | jq -r '.Credentials | \"export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\\nexport AWS_SESSION_TOKEN=\(.SessionToken)\\n\"')\""
-              echo "export KUBECONFIG=\"/tmp/kubeconfig-${CLUSTER_NAME}.conf\""
-              echo "aws eks update-kubeconfig --region \"${AWS_DEFAULT_REGION}\" --name \"${CLUSTER_NAME}\" --kubeconfig \"\$KUBECONFIG\""
-              echo '```'
-            ) | tee -a "${GITHUB_STEP_SUMMARY}"
-          fi
-
-          if grep -Eq '(^| )copilot ' "${TMP_DIR}/run.sh" && ! command -v copilot &> /dev/null ; then
-            echo "📦 *** Installing copilot"
-            brew install copilot
-            copilot --version
-          fi
-
-          if grep -Eq '(^| )cilium ' "${TMP_DIR}/run.sh" && ! command -v cilium &> /dev/null ; then
-            echo "📦 *** Installing cilium"
-            brew install cilium-cli
-          fi
-
-          if grep -Eq '(^| )rain ' "${TMP_DIR}/run.sh" && ! command -v rain &> /dev/null ; then
-            echo "📦 *** Installing rain"
-            brew install rain
-          fi
-
-          if grep -Eq '(^| )velero ' "${TMP_DIR}/run.sh" && ! command -v velero &> /dev/null ; then
-            echo "📦 *** Installing velero"
-            brew install velero
-          fi
-
-          chmod a+x "${TMP_DIR}/run.sh"
-          "${TMP_DIR}/run.sh"
+          mise run "${ACTION}:${POSTS}"

--- a/.github/workflows/post_tests.yml
+++ b/.github/workflows/post_tests.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Install mise and dependencies
+        run: |
+          set -euxo pipefail
+          curl https://mise.run | sh
+          echo "$HOME/.local/share/mise/bin" >> "${GITHUB_PATH}"
+          echo "$HOME/.local/share/mise/shims" >> "${GITHUB_PATH}"
+
       - name: "${{ inputs.action }} | ${{ inputs.posts }}"
         env:
           ACTION: ${{ inputs.action }}
@@ -76,8 +83,5 @@ jobs:
         run: |
           set -euxo pipefail
 
-          curl https://mise.run | sh
-          echo "$HOME/.local/share/mise/bin" >> "${GITHUB_PATH}"
-          echo "$HOME/.local/share/mise/shims" >> "${GITHUB_PATH}"
 
           mise run "${ACTION}:${POSTS}"

--- a/_posts/2022/2022-11-27-cheapest-amazon-eks.md
+++ b/_posts/2022/2022-11-27-cheapest-amazon-eks.md
@@ -66,7 +66,7 @@ up a few environment variables, such as:
 # AWS Region
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 # Hostname / FQDN definitions
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 # Base Domain: k8s.mylabs.dev
 export BASE_DOMAIN="${CLUSTER_FQDN#*.}"
 # Cluster Name: k01

--- a/_posts/2022/2022-12-24-amazon-eks-karpenter-tests.md
+++ b/_posts/2022/2022-12-24-amazon-eks-karpenter-tests.md
@@ -29,7 +29,7 @@ The following variables are used in the subsequent steps:
 
 ```bash
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 export CLUSTER_NAME="${CLUSTER_FQDN%%.*}"
 export TMP_DIR="${TMP_DIR:-${PWD}}"
 export KUBECONFIG="${KUBECONFIG:-${TMP_DIR}/${CLUSTER_FQDN}/kubeconfig-${CLUSTER_NAME}.conf}"

--- a/_posts/2023/2023-03-08-trivy-operator-grafana.md
+++ b/_posts/2023/2023-03-08-trivy-operator-grafana.md
@@ -48,7 +48,7 @@ The following variables are used in the subsequent steps:
 
 ```bash
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 export CLUSTER_NAME="${CLUSTER_FQDN%%.*}"
 export TMP_DIR="${TMP_DIR:-${PWD}}"
 export KUBECONFIG="${KUBECONFIG:-${TMP_DIR}/${CLUSTER_FQDN}/kubeconfig-${CLUSTER_NAME}.conf}"

--- a/_posts/2023/2023-03-20-velero-and-cert-manager.md
+++ b/_posts/2023/2023-03-20-velero-and-cert-manager.md
@@ -35,7 +35,7 @@ The following variables are used in the subsequent steps:
 
 ```bash
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 export CLUSTER_NAME="${CLUSTER_FQDN%%.*}"
 export MY_EMAIL="petr.ruzicka@gmail.com"
 export TMP_DIR="${TMP_DIR:-${PWD}}"

--- a/_posts/2023/2023-04-01-secrets-store-csi-driver-reloader.md
+++ b/_posts/2023/2023-04-01-secrets-store-csi-driver-reloader.md
@@ -59,7 +59,7 @@ The following variables are used in the subsequent steps:
 
 ```bash
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 export CLUSTER_NAME="${CLUSTER_FQDN%%.*}"
 export TMP_DIR="${TMP_DIR:-${PWD}}"
 export KUBECONFIG="${KUBECONFIG:-${TMP_DIR}/${CLUSTER_FQDN}/kubeconfig-${CLUSTER_NAME}.conf}"

--- a/_posts/2023/2023-08-03-cilium-amazon-eks.md
+++ b/_posts/2023/2023-08-03-cilium-amazon-eks.md
@@ -87,7 +87,7 @@ few environment variables, such as:
 # AWS Region
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 # Hostname / FQDN definitions
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 # Base Domain: k8s.mylabs.dev
 export BASE_DOMAIN="${CLUSTER_FQDN#*.}"
 # Cluster Name: k01

--- a/_posts/2023/2023-09-25-secure-cheap-amazon-eks.md
+++ b/_posts/2023/2023-09-25-secure-cheap-amazon-eks.md
@@ -75,7 +75,7 @@ few environment variables, such as:
 # AWS Region
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 # Hostname / FQDN definitions
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 # Base Domain: k8s.mylabs.dev
 export BASE_DOMAIN="${CLUSTER_FQDN#*.}"
 # Cluster Name: k01

--- a/_posts/2024/2024-05-03-secure-cheap-amazon-eks-with-pod-identities.md
+++ b/_posts/2024/2024-05-03-secure-cheap-amazon-eks-with-pod-identities.md
@@ -78,7 +78,7 @@ few environment variables, such as:
 # AWS Region
 export AWS_REGION="${AWS_REGION:-us-east-1}"
 # Hostname / FQDN definitions
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 # Base Domain: k8s.mylabs.dev
 export BASE_DOMAIN="${CLUSTER_FQDN#*.}"
 # Cluster Name: k01

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -1163,7 +1163,7 @@ Remove the Query logging configuration:
 ```sh
 AWS_VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:alpha.eksctl.io/cluster-name,Values=${CLUSTER_NAME}" --query 'Vpcs[*].VpcId' --output text)
 
-if [[ -n "${AWS_VPC_ID}"  ]]; then
+if [[ -n "${AWS_VPC_ID}" ]]; then
   AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID=$(aws route53resolver list-resolver-query-log-config-associations \
     --query "ResolverQueryLogConfigAssociations[?ResourceId=='${AWS_VPC_ID}'].ResolverQueryLogConfigId" --output text)
   aws route53resolver disassociate-resolver-query-log-config \
@@ -1171,7 +1171,7 @@ if [[ -n "${AWS_VPC_ID}"  ]]; then
     --resource-id "${AWS_VPC_ID}"
 fi
 
-aws route53resolver list-resolver-query-log-configs --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" | jq  -r '.[]' |
+aws route53resolver list-resolver-query-log-configs --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" | jq -r '.[]' |
   while read -r AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID; do
     aws route53resolver delete-resolver-query-log-config --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID}"
   done

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -1166,9 +1166,9 @@ AWS_VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:alpha.eksctl.io/cluster-n
 if [[ -n "${AWS_VPC_ID}" ]]; then
   AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID=$(aws route53resolver list-resolver-query-log-config-associations \
     --query "ResolverQueryLogConfigAssociations[?ResourceId=='${AWS_VPC_ID}'].ResolverQueryLogConfigId" --output text)
-  aws route53resolver disassociate-resolver-query-log-config \
-    --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" \
-    --resource-id "${AWS_VPC_ID}"
+  if [[ -n "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" ]]; then
+    aws route53resolver disassociate-resolver-query-log-config --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" --resource-id "${AWS_VPC_ID}"
+  fi
 fi
 
 aws route53resolver list-resolver-query-log-configs --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" | jq -r '.[]' |

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -74,7 +74,7 @@ few environment variables, such as:
 # AWS Region
 export AWS_REGION="${AWS_REGION:-us-east-1}"
 # Hostname / FQDN definitions
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 # Base Domain: k8s.mylabs.dev
 export BASE_DOMAIN="${CLUSTER_FQDN#*.}"
 # Cluster Name: k01

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -1158,31 +1158,31 @@ helm upgrade --install --version "${HOMEPAGE_HELM_CHART_VERSION}" --namespace ho
 
 ![Clean-up](https://raw.githubusercontent.com/aws-samples/eks-workshop/65b766c494a5b4f5420b2912d8373c4957163541/static/images/cleanup.svg){:width="300"}
 
+Remove the Query logging configuration:
+
+```sh
+AWS_VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:alpha.eksctl.io/cluster-name,Values=${CLUSTER_NAME}" --query 'Vpcs[*].VpcId' --output text)
+
+if [[ -n "${AWS_VPC_ID}"  ]]; then
+  AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID=$(aws route53resolver list-resolver-query-log-config-associations \
+    --query "ResolverQueryLogConfigAssociations[?ResourceId=='${AWS_VPC_ID}'].ResolverQueryLogConfigId" --output text)
+  aws route53resolver disassociate-resolver-query-log-config \
+    --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" \
+    --resource-id "${AWS_VPC_ID}"
+fi
+
+aws route53resolver list-resolver-query-log-configs --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" | jq  -r '.[]' |
+  while read -r AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID; do
+    aws route53resolver delete-resolver-query-log-config --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID}"
+  done
+```
+
 Remove the EKS cluster and its created components:
 
 ```sh
 if eksctl get cluster --name="${CLUSTER_NAME}"; then
   eksctl delete cluster --name="${CLUSTER_NAME}" --force
 fi
-```
-
-Remove the Query logging configuration:
-
-```sh
-AWS_VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:alpha.eksctl.io/cluster-name,Values=${CLUSTER_NAME}" --query 'Vpcs[*].VpcId' --output text)
-
-AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID=$(aws route53resolver list-resolver-query-log-config-associations \
-  --query "ResolverQueryLogConfigAssociations[?ResourceId=='${AWS_VPC_ID}'].ResolverQueryLogConfigId" --output text)
-
-aws route53resolver disassociate-resolver-query-log-config \
-  --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" \
-  --resource-id "${AWS_VPC_ID}"
-
-AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID=$(aws route53resolver list-resolver-query-log-configs \
-  --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" --output text)
-
-aws route53resolver delete-resolver-query-log-config \
-  --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID}"
 ```
 
 Remove the Route 53 DNS records from the DNS Zone:

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -1158,7 +1158,15 @@ helm upgrade --install --version "${HOMEPAGE_HELM_CHART_VERSION}" --namespace ho
 
 ![Clean-up](https://raw.githubusercontent.com/aws-samples/eks-workshop/65b766c494a5b4f5420b2912d8373c4957163541/static/images/cleanup.svg){:width="300"}
 
-Remove the Query logging configuration:
+Remove the EKS cluster and its created components:
+
+```sh
+if eksctl get cluster --name="${CLUSTER_NAME}"; then
+  eksctl delete cluster --name="${CLUSTER_NAME}" --force
+fi
+```
+
+Disassociate a Route 53 Resolver query log configuration from an Amazon VPC:
 
 ```sh
 AWS_VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:alpha.eksctl.io/cluster-name,Values=${CLUSTER_NAME}" --query 'Vpcs[*].VpcId' --output text)
@@ -1169,19 +1177,6 @@ if [[ -n "${AWS_VPC_ID}" ]]; then
   if [[ -n "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" ]]; then
     aws route53resolver disassociate-resolver-query-log-config --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ASSOCIATIONS_RESOLVER_QUERY_LOG_CONFIG_ID}" --resource-id "${AWS_VPC_ID}"
   fi
-fi
-
-aws route53resolver list-resolver-query-log-configs --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" | jq -r '.[]' |
-  while read -r AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID; do
-    aws route53resolver delete-resolver-query-log-config --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID}"
-  done
-```
-
-Remove the EKS cluster and its created components:
-
-```sh
-if eksctl get cluster --name="${CLUSTER_NAME}"; then
-  eksctl delete cluster --name="${CLUSTER_NAME}" --force
 fi
 ```
 
@@ -1198,6 +1193,15 @@ if [[ -n "${CLUSTER_FQDN_ZONE_ID}" ]]; then
         --output text --query 'ChangeInfo.Id'
     done
 fi
+```
+
+Clean up AWS Route 53 Resolver query log configurations:
+
+```sh
+aws route53resolver list-resolver-query-log-configs --query "ResolverQueryLogConfigs[?Name=='${CLUSTER_NAME}-vpc-dns-logs'].Id" | jq -r '.[]' |
+  while read -r AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID; do
+    aws route53resolver delete-resolver-query-log-config --resolver-query-log-config-id "${AWS_CLUSTER_ROUTE53_RESOLVER_QUERY_LOG_CONFIG_ID}"
+  done
 ```
 
 Remove the CloudFormation stack:

--- a/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
+++ b/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
@@ -54,7 +54,7 @@ The following variables are used in the subsequent steps:
 
 ```bash
 export AWS_REGION="${AWS_REGION:-us-east-1}"
-export CLUSTER_FQDN="k01.k8s.mylabs.dev"
+export CLUSTER_FQDN="${CLUSTER_FQDN:-k01.k8s.mylabs.dev}"
 export CLUSTER_NAME="${CLUSTER_FQDN%%.*}"
 export MY_EMAIL="petr.ruzicka@gmail.com"
 export TMP_DIR="${TMP_DIR:-${PWD}}"

--- a/mise.toml
+++ b/mise.toml
@@ -40,9 +40,9 @@ GOOGLE_CLIENT_ID = { value = "{{ env.GOOGLE_CLIENT_ID }}", redact = true }
 GOOGLE_CLIENT_SECRET = { value = "{{ env.GOOGLE_CLIENT_SECRET }}", redact = true }
 
 # Cluster Configuration
-CLUSTER_NAME = "k01"
-CLUSTER_FQDN = "{{ env.CLUSTER_NAME }}.k8s.mylabs.dev"
-TAGS = "product_id='12345',used_for=dev,owner=petr.ruzicka@gmail.com,cluster=k01.k8s.mylabs.dev"
+CLUSTER_FQDN = "{{ get_env(name='CLUSTER_FQDN', default='k01.k8s.mylabs.dev') }}"
+CLUSTER_NAME = "{{ env.CLUSTER_FQDN | split(pat='.') | first }}"
+TAGS = "product_id='12345',used_for=dev,owner=petr.ruzicka@gmail.com,cluster={{ env.CLUSTER_FQDN }}"
 
 # Path Configuration
 TMP_DIR = "{{ cwd }}/tmp"

--- a/scripts/mise-create-delete-posts.sh
+++ b/scripts/mise-create-delete-posts.sh
@@ -62,9 +62,11 @@ echo "⏰ *** $(date)"
 echo "⏰ *** $(date)"
 
 rm -v "${RUN_FILE}"
+
 if [[ "${GITHUB_STEP_SUMMARY}" =~ ${TMP_DIR} ]] && [[ -f "${GITHUB_STEP_SUMMARY}" ]]; then
   rm -v "${GITHUB_STEP_SUMMARY}"
 fi
+
 if [[ -z "$(ls -A "${TMP_DIR}")" ]]; then
   rmdir -v "${TMP_DIR}"
 else


### PR DESCRIPTION
The update to the post_tests workflow enhances the configuration and execution of post-processing actions. Key changes include adjustments to input handling and the introduction of new default values.

- Consolidated post options into a single line for clarity.

- Changed the default action from "build + destroy" to "create."

- Introduced a new input for cluster FQDN.

- Updated the script to utilize the new input structure and simplified the execution command.

- Modified the environment variable for cluster FQDN in the markdown file to allow for default values.