### PR TITLE
fix: correct hostname retrieval in assume-role command

### DIFF
--- a/scripts/mise-create-delete-posts.sh
+++ b/scripts/mise-create-delete-posts.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 : "${TMP_DIR:="${PWD}"}"
 : "${RUN_FILE:="${TMP_DIR}/${1//[:|]/_}.sh"}"
 
-eval "$(aws sts assume-role --role-arn "${AWS_ROLE_TO_ASSUME}" --role-session-name "$USER@$(hostname -f)-k8s-$(date +%s)" --duration-seconds 36000 | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')"
+eval "$(aws sts assume-role --role-arn "${AWS_ROLE_TO_ASSUME}" --role-session-name "$USER@${HOSTNAME}-k8s-$(date +%s)" --duration-seconds 36000 | jq -r '.Credentials | "export AWS_ACCESS_KEY_ID=\(.AccessKeyId)\nexport AWS_SECRET_ACCESS_KEY=\(.SecretAccessKey)\nexport AWS_SESSION_TOKEN=\(.SessionToken)\n"')"
 
 echo "💡 *** $*"
 


### PR DESCRIPTION
Correct the hostname retrieval method in the assume-role command to ensure accurate session naming.

- Changed `hostname -f` to `${HOSTNAME}` for consistency and reliability in the script.