### PR TITLE
ci: update GitHub Actions and fix lycheecache guard

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: commit-check/commit-check-action@443fb6a114414358496e6243105294c3b11610c5 # v2.4.2
+      - uses: commit-check/commit-check-action@2fe41833054c561710099d8e3e22bbeab4fe204a # v2.5.0
         env:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -36,7 +36,9 @@ jobs:
       # https://github.com/lycheeverse/lychee/issues/1734
       - name: Remove unavailable URLs from cache to check them again
         run: |
-          sed -i '/,,/d' .lycheecache
+          if [[ -f .lycheecache ]]; then
+            sed -i '/,,/d' .lycheecache
+          fi
 
       - name: Link Checker
         env:

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -19,4 +19,4 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+      - uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1.10.4

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
+        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Bump `commit-check/commit-check-action` v2.4.2 → v2.5.0
- Bump `codelytv/pr-size-labeler` v1.10.3 → v1.10.4
- Bump `renovatebot/github-action` v46.1.4 → v46.1.7
- Guard `sed` on `.lycheecache` with file existence check to prevent errors when the cache file doesn't exist