### PR TITLE
fix: ignore copilot agent workflows in projects generator

### DIFF
--- a/scripts/generate-projects.sh
+++ b/scripts/generate-projects.sh
@@ -57,8 +57,8 @@ while read -r GITHUB_REPOSITORY_TITLE_TMP; do
   GITHUB_REPOSITORY_TOPICS=$(jq -r '[.repositoryTopics[].name] | join(", ")' <<< "${GITHUB_REPOSITORY_TITLE_TMP}")
   GITHUB_REPOSITORY_HOMEPAGEURL=$(jq -r '.homepageUrl' <<< "${GITHUB_REPOSITORY_TITLE_TMP}")
   GITHUB_REPOSITORY_DEFAULT_BRANCH=$(jq -r '.defaultBranchRef.name' <<< "${GITHUB_REPOSITORY_TITLE_TMP}")
-  # Remove pages-build-deployment and any obsolete GitHub Actions which doesn't have path like "vuepress-build"
-  GITHUB_REPOSITORY_CI_CD_STATUS=$(curl -s --header "authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY_NAME}/actions/workflows" | jq -r 'del(.workflows[] | select((.path=="dynamic/pages/pages-build-deployment") or (.path==""))) | .workflows[] | "  [![GitHub Actions status - " + .name + "](" + .badge_url + ")](" + .html_url | gsub("/blob/.*/.github/"; "/actions/") + ")"' | sort --ignore-case)
+  # Remove pages-build-deployment, Copilot agent workflows, and any obsolete GitHub Actions which doesn't have path like "vuepress-build"
+  GITHUB_REPOSITORY_CI_CD_STATUS=$(curl -s --header "authorization: Bearer ${GITHUB_TOKEN}" "https://api.github.com/repos/${GITHUB_REPOSITORY_NAME}/actions/workflows" | jq -r 'del(.workflows[] | select((.path=="dynamic/pages/pages-build-deployment") or (.path=="") or (.path | startswith("dynamic/copilot-")))) | .workflows[] | "  [![GitHub Actions status - " + .name + "](" + .badge_url + ")](" + .html_url | gsub("/blob/.*/.github/"; "/actions/") + ")"' | sort --ignore-case)
   GITHUB_REPOSITORY_URL_STRING=$(if [[ -n "${GITHUB_REPOSITORY_HOMEPAGEURL}" ]]; then echo -e "\n- Website: <${GITHUB_REPOSITORY_HOMEPAGEURL}>"; fi)
   cat << EOF >> "${DESTINATION_FILE}"
 


### PR DESCRIPTION
## Summary

- Filters out GitHub Copilot agent workflows (paths starting with `dynamic/copilot-`) when generating CI/CD status badges in `_tabs/projects.md`.
- Prevents dynamic Copilot workflows such as `copilot-swe-agent/copilot` and `copilot-pull-request-reviewer/copilot-pull-request-reviewer` from appearing in the projects page (as seen in #507).

## Change

Extends the existing `jq` filter in `scripts/generate-projects.sh` (currently filtering `dynamic/pages/pages-build-deployment` and empty paths) with `(.path | startswith("dynamic/copilot-"))`.

Verified the path format via the GitHub Actions API:

```
dynamic/copilot-swe-agent/copilot
```

## Validation

- `shellcheck scripts/generate-projects.sh` — passes
- `shfmt --case-indent --indent 2 --space-redirects -d scripts/generate-projects.sh` — passes