### PR TITLE
fix: exclude LinkedIn from lychee link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -2,6 +2,7 @@
 /\.github/workflows/post_tests.yml
 \.elb\.amazonaws\.com
 \.local
+access\.redhat\.com
 cdn\.com
 eko\.one\.pl
 ftp\.xvx\.cz
@@ -22,8 +23,11 @@ web\.archive\.org
 websvn\.xvx\.cz
 www\.conventionalcommits\.org
 www\.cvedetails\.com
+www\.dell\.com
 www\.facebook\.com/sharer/sharer\.php\?title=TITLE&u=URL
+www\.freedesktop\.org
 www\.gnu\.org
+www\.linkedin\.com
 www\.mysql\.com
 www\.reddit\.com/submit\?url=
 # keep-sorted end


### PR DESCRIPTION
## Summary

- Add `www\.linkedin\.com` to `.lycheeignore` to prevent link checker failures
- LinkedIn returns HTTP 999 (bot detection) which consistently fails CI

Fixes: https://github.com/ruzickap/ruzickap.github.io/actions/runs/25649017759