### PR TITLE
chore(deps): update github actions pin versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Initialize CodeQL
         # Does not support arm64
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: actions
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:actions"

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: commit-check/commit-check-action@2239d8980732e84a380552fdd71e1d49e149baf3 # v2.6.1
+      - uses: commit-check/commit-check-action@f237ed0085f49444ab5c85bdfa5cdcd490fc09c5 # v2.7.0
         env:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72

--- a/.github/workflows/gh-pages-build.yml
+++ b/.github/workflows/gh-pages-build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Setup Ruby
         # zizmor: ignore[cache-poisoning] -- bundler-cache in a trusted workflow with no untrusted inputs
-        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: 3.4.9
           bundler-cache: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -40,7 +40,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif
           # Set category to distinguish from other security scans

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           # keep-sorted start
           close-issue-message: |

--- a/_posts/2013/2013-06-08-last-post.md
+++ b/_posts/2013/2013-06-08-last-post.md
@@ -10,18 +10,18 @@ tags: []
 > <https://linux-old.xvx.cz/2013/06/last-post/>
 {: .prompt-info }
 
-I decided to move this blog to [Google's Blogger](https://www.blogger.com),
+I decided to move this blog to [Google's Blogger](https://www.blogger.com/about/),
 because I don't want to run my own server (hardware) any more. The domain will
 be the same, but all the RSS feeds and pages will have a new structure.
 
-The [Wordpress](https://www.wordpress.org) engine is much better than Google's,
+The [WordPress](https://wordpress.org) engine is much better than Google's,
 but there are no free hosting services where you can use your own domain (not to
 buy one).
 
 I found just these:
 
-- [GitHub](https://www.github.com)
-- [Blogger](https://www.blogger.com)
+- [GitHub](https://github.com)
+- [Blogger](https://www.blogger.com/about/)
 - [Tumblr](https://www.tumblr.com)
 - [Weebly](https://www.weebly.com)
 

--- a/_posts/2014/2014-04-16-turris-openwrt-configuration.md
+++ b/_posts/2014/2014-04-16-turris-openwrt-configuration.md
@@ -197,7 +197,7 @@ uci set rainbow.@led[-1].status=auto
 ```
 
 Add favorite packages and configure [Midnight
-Commander](https://www.midnight-commander.org/),
+Commander](https://midnight-commander.org/),
 [screen](https://www.gnu.org/software/screen/) and email.
 
 ```bash
@@ -274,7 +274,7 @@ uci set 'ddns.myddns.update_url=http://www.duckdns.org/update?domains=[DOMAIN]&t
 ```
 
 Modify the lighttpd web server to enable ssl (https), serve personal pages and
-[Transmission](https://www.transmissionbt.com/):
+[Transmission](https://transmissionbt.com/):
 
 ```bash
 opkg install lighttpd-mod-proxy
@@ -503,7 +503,7 @@ Here is the example how the stats look like:
 
 ![vnStat network traffic statistics screenshot](https://github.com/ruzickap/linux.xvx.cz/raw/gh-pages/pics/turris/screenshot-gate-xvx-cz-myadmin-vnstat.png)
 
-[Transmission](https://www.transmissionbt.com/) bittorrent client configuration:
+[Transmission](https://transmissionbt.com/) bittorrent client configuration:
 
 ```bash
 opkg install transmission-remote transmission-web
@@ -573,7 +573,7 @@ EOF
 ```
 
 To access the transmission using RPC (for example from Android [Transdroid
-client](https://www.transdroid.org/)) you need to specify the following:
+client](https://transdroid.org/)) you need to specify the following:
 `https://ruzickap@gate.xvx.cz:443/myadmin/transmission/rpc`
 
 Save and reboot to apply all changes:

--- a/_posts/2023/2023-03-20-velero-and-cert-manager.md
+++ b/_posts/2023/2023-03-20-velero-and-cert-manager.md
@@ -18,7 +18,7 @@ certificates, it can be handy to back them up and restore them if the cluster
 needs to be recreated.
 
 Here are a few steps on how to install [Velero](https://velero.io/) and the
-[backup and restore](https://cert-manager.io/docs/tutorials/backup/) procedure
+[backup and restore](https://cert-manager.io/docs/devops-tips/backup/) procedure
 for cert-manager objects.
 
 Links:

--- a/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
+++ b/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
@@ -21,7 +21,7 @@ certificates, it is useful to back them up and restore them when recreating
 the cluster.
 
 Here are a few steps to install [Velero](https://velero.io/) and perform the
-[backup and restore](https://cert-manager.io/docs/tutorials/backup/) procedure
+[backup and restore](https://cert-manager.io/docs/devops-tips/backup/) procedure
 for cert-manager objects.
 
 Links:


### PR DESCRIPTION
Update GitHub Actions pinned SHA versions:

- `github/codeql-action`: v4.35.5 → v4.36.0
- `commit-check/commit-check-action`: v2.6.1 → v2.7.0
- `ruby/setup-ruby`: v1.306.0 → v1.310.0
- `actions/stale`: v10.2.0 → v10.3.0