### PR TITLE
fix: update AWS CLI URL and remove namespace from ClusterIssuer

### DIFF
--- a/_posts/2018/2018-01-20-how-i-began-with-darktable.md
+++ b/_posts/2018/2018-01-20-how-i-began-with-darktable.md
@@ -16,7 +16,7 @@ are free. Because I switched from [JPEG](https://en.wikipedia.org/wiki/JPEG) to
 editor that could help me with this task.... and I found
 [Darktable](https://www.darktable.org/).
 
-![Darktable darkroom interface screenshot](https://ia800104.us.archive.org/6/items/darktable-2.4.0-src/screenshot_darkroom1.jpg)
+![Darktable darkroom interface screenshot](https://ia601609.us.archive.org/8/items/darktable-2.4.0-src/screenshot_darkroom1.jpg)
 
 Darktable is used by many professional photographers and starting with it is not
 very easy.

--- a/_posts/2022/2022-11-27-cheapest-amazon-eks.md
+++ b/_posts/2022/2022-11-27-cheapest-amazon-eks.md
@@ -78,7 +78,7 @@ Install the necessary tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
@@ -825,7 +825,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging-dns
-  namespace: cert-manager
   labels:
     letsencrypt: staging
 spec:

--- a/_posts/2023/2023-03-20-velero-and-cert-manager.md
+++ b/_posts/2023/2023-03-20-velero-and-cert-manager.md
@@ -63,7 +63,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-production-dns
-  namespace: cert-manager
   labels:
     letsencrypt: production
 spec:

--- a/_posts/2023/2023-08-03-cilium-amazon-eks.md
+++ b/_posts/2023/2023-08-03-cilium-amazon-eks.md
@@ -93,7 +93,7 @@ Install the necessary tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [cilium](https://github.com/cilium/cilium-cli)
@@ -1284,7 +1284,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging-dns
-  namespace: cert-manager
   labels:
     letsencrypt: staging
 spec:

--- a/_posts/2023/2023-09-25-secure-cheap-amazon-eks.md
+++ b/_posts/2023/2023-09-25-secure-cheap-amazon-eks.md
@@ -83,7 +83,7 @@ Install the required tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
@@ -1072,7 +1072,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging-dns
-  namespace: cert-manager
   labels:
     letsencrypt: staging
 spec:

--- a/_posts/2024/2024-04-27-exploit-vulnerability-wordpress-plugin-kali-linux-1.md
+++ b/_posts/2024/2024-04-27-exploit-vulnerability-wordpress-plugin-kali-linux-1.md
@@ -23,7 +23,7 @@ I will cover the following steps:
 
 Requirements:
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)

--- a/_posts/2024/2024-05-03-secure-cheap-amazon-eks-with-pod-identities.md
+++ b/_posts/2024/2024-05-03-secure-cheap-amazon-eks-with-pod-identities.md
@@ -86,7 +86,7 @@ Install the required tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
@@ -1423,7 +1423,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging-dns
-  namespace: cert-manager
   labels:
     letsencrypt: staging
 spec:

--- a/_posts/2024/2024-05-09-exploit-vulnerability-wordpress-plugin-kali-linux-2.md
+++ b/_posts/2024/2024-05-09-exploit-vulnerability-wordpress-plugin-kali-linux-2.md
@@ -27,7 +27,7 @@ I will cover the following steps:
 
 Requirements:
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [Colima](https://github.com/abiosoft/colima) / [Docker](https://www.docker.com/)
   / [Rancher Desktop](https://rancherdesktop.io/) / ...
 - [copilot](https://github.com/aws/copilot-cli)

--- a/_posts/2024/2024-07-07-detect-a-hacker-attacks-eks-vm.md
+++ b/_posts/2024/2024-07-07-detect-a-hacker-attacks-eks-vm.md
@@ -41,7 +41,7 @@ and [2]({%post_url /2024/2024-05-09-exploit-vulnerability-wordpress-plugin-kali-
 
 Requirements:
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [rain](https://github.com/aws-cloudformation/rain)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -84,7 +84,7 @@ Install the required tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
@@ -846,7 +846,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging-dns
-  namespace: cert-manager
   labels:
     letsencrypt: staging
 spec:

--- a/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
+++ b/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
@@ -34,7 +34,7 @@ Links:
 
 - An Amazon EKS Auto Mode cluster (as described in
   "[Build secure and cheap Amazon EKS Auto Mode]({% post_url /2024/2024-12-14-secure-cheap-amazon-eks-auto %})")
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [Helm](https://helm.sh)
 - [kubectl](https://github.com/kubernetes/kubectl)
@@ -74,7 +74,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-production-dns
-  namespace: cert-manager
   labels:
     letsencrypt: production
 spec:

--- a/_posts/2025/2025-05-27-mcp-servers-k8s.md
+++ b/_posts/2025/2025-05-27-mcp-servers-k8s.md
@@ -39,7 +39,7 @@ powered by MCP servers and local LLM inference running on your EKS cluster.
 
 - Amazon EKS Auto Mode cluster (described in
   [Build secure and cheap Amazon EKS Auto Mode]({% post_url /2024/2024-12-14-secure-cheap-amazon-eks-auto %}))
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [Helm](https://helm.sh)
 - [kubectl](https://github.com/kubernetes/kubectl)

--- a/_posts/2025/2025-07-10-ollama-k8s-exploitation.md
+++ b/_posts/2025/2025-07-10-ollama-k8s-exploitation.md
@@ -54,7 +54,7 @@ sequenceDiagram
 
 Before we begin, ensure you have the following tools installed and configured:
 
-- [AWS CLI](https://aws.amazon.com/cli/) with appropriate permissions to create
+- [AWS CLI](https://builder.aws.com/build/tools) with appropriate permissions to create
   resources.
 - [rain](https://github.com/aws-cloudformation/rain): A delightful CLI for AWS
   CloudFormation.

--- a/_posts/2026/2026-01-13-amazon-eks-grafana-stack.md
+++ b/_posts/2026/2026-01-13-amazon-eks-grafana-stack.md
@@ -82,7 +82,7 @@ Install the required tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)

--- a/_posts/2026/2026-01-26-bootstrap-eks-auto-mode-bootstrap-ack-kro-velero.md
+++ b/_posts/2026/2026-01-26-bootstrap-eks-auto-mode-bootstrap-ack-kro-velero.md
@@ -21,7 +21,7 @@ them to the new EKS Auto Mode Cluster — effectively making it self-managed.
 ## Requirements
 
 - [AWS account](https://aws.amazon.com/) with appropriate permissions
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [Helm](https://helm.sh/)
 - [kind](https://kind.sigs.k8s.io/)

--- a/_posts/2026/2026-03-04-amazon-eks-envoy-gateway-argocd.md
+++ b/_posts/2026/2026-03-04-amazon-eks-envoy-gateway-argocd.md
@@ -96,7 +96,7 @@ Install the required tools:
 {: .prompt-tip }
 <!-- prettier-ignore-end -->
 
-- [AWS CLI](https://aws.amazon.com/cli/)
+- [AWS CLI](https://builder.aws.com/build/tools)
 - [eksctl](https://eksctl.io/)
 - [kubectl](https://github.com/kubernetes/kubectl)
 
@@ -777,7 +777,6 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-production-dns
-  namespace: cert-manager
   labels:
     letsencrypt: production
 spec:


### PR DESCRIPTION
## Changes

- Update AWS CLI link from `https://aws.amazon.com/cli/` to `https://builder.aws.com/build/tools` across all posts
- Remove incorrect `namespace: cert-manager` field from `ClusterIssuer` resources (cluster-scoped resources do not have a namespace)
- Update darktable image URL to working archive.org link

## Files changed

16 post files updated with minor link/YAML corrections.