### PR TITLE
fix: remove hidden Unicode characters (non-breaking spaces) from posts

### DIFF
--- a/_posts/2015/2015-12-24-atom-editor-atomio.md
+++ b/_posts/2015/2015-12-24-atom-editor-atomio.md
@@ -22,7 +22,7 @@ Maybe you can also use this "Atom Cheatsheet" to help you learn the shortcuts:
 ![Atom editor keyboard shortcuts cheatsheet](https://github.com/ruzickap/cheatsheet-atom/releases/download/v1.1.0/atom_cheatsheet.jpg)
 
 You can download the available formats from
-GitHub: [https://github.com/ruzickap/cheatsheet-atom/releases](https://github.com/ruzickap/cheatsheet-atom/releases)
+GitHub: [https://github.com/ruzickap/cheatsheet-atom/releases](https://github.com/ruzickap/cheatsheet-atom/releases)
 
 - [Atom Cheatsheet - PDF](https://github.com/ruzickap/cheatsheet-atom/releases/download/v1.1.0/atom_cheatsheet.pdf)
 - [Atom Cheatsheet - SVG](https://github.com/ruzickap/cheatsheet-atom/releases/download/v1.1.0/atom_cheatsheet.svg)

--- a/_posts/2017/2017-02-13-provision-windows-server-2016-in-aws-using-ansible-via-cloudformation.md
+++ b/_posts/2017/2017-02-13-provision-windows-server-2016-in-aws-using-ansible-via-cloudformation.md
@@ -23,12 +23,12 @@ Here is the file/directory structure:
 ```text
 .
 ├── group_vars
-│   └── all
+│   └── all
 ├── tasks
-│   ├── create_cf_stack.yml
-│   └── win.yml
+│   ├── create_cf_stack.yml
+│   └── win.yml
 ├── templates
-│   └── aws_cf_stack.yml.j2
+│   └── aws_cf_stack.yml.j2
 ├── run_aws.sh
 └── site_aws.yml
 ```

--- a/_posts/2017/2017-07-16-how-to-build-pxe-fedora-26-live-image.md
+++ b/_posts/2017/2017-07-16-how-to-build-pxe-fedora-26-live-image.md
@@ -14,7 +14,7 @@ Sometimes it may be handy to PXE boot live image (running only in memory) over
 the network.
 
 On this
-page [https://lukas.zapletalovi.com/2016/08/hidden-feature-of-fedora-24-live-pxe-boot.html](https://lukas.zapletalovi.com/2016/08/hidden-feature-of-fedora-24-live-pxe-boot.html)
+page [https://lukas.zapletalovi.com/2016/08/hidden-feature-of-fedora-24-live-pxe-boot.html](https://lukas.zapletalovi.com/2016/08/hidden-feature-of-fedora-24-live-pxe-boot.html)
 I found an easy way to boot Fedora Live CD over the network.
 
 In my case I prefer to build my own image to reduce the size, because I do not

--- a/_posts/2017/2017-10-24-create-windows-image-using-packer-and-ansible-and-then-run-it-in-vagrant-libvirt.md
+++ b/_posts/2017/2017-10-24-create-windows-image-using-packer-and-ansible-and-then-run-it-in-vagrant-libvirt.md
@@ -210,16 +210,16 @@ Directory structure after build completed:
 ```text
 .
 ├── ansible
-│   └── win.yml
+│   └── win.yml
 ├── http
-│   └── windows-server-2016
-│   └── Autounattend.xml
+│   └── windows-server-2016
+│   └── Autounattend.xml
 ├── packer_cache
-│   └── 49f719e23c56a779a991c4b4ad1680b8363918cd0bfd9ac6b52697d78a309855.iso
+│   └── 49f719e23c56a779a991c4b4ad1680b8363918cd0bfd9ac6b52697d78a309855.iso
 ├── scripts
-│   └── win-common
-│   ├── fixnetwork.ps1
-│   └── remove_nic.bat
+│   └── win-common
+│   ├── fixnetwork.ps1
+│   └── remove_nic.bat
 ├── Vagrantfile-windows.template
 ├── virtio-win.iso
 ├── windows-server-2016-eval.json

--- a/_posts/2019/2019-10-21-other-posts.md
+++ b/_posts/2019/2019-10-21-other-posts.md
@@ -11,7 +11,7 @@ tags: [kubernetes, istio, harbor, flux, amazon-eks]
 {: .prompt-info }
 
 It's been some time since I posted something. Unfortunately I prefer to write
-some blog posts in [Markdown](https://guides.github.com/features/mastering-markdown/) 
+some blog posts in [Markdown](https://guides.github.com/features/mastering-markdown/)
 instead of writing it here.
 
 Most of them are related to Kubernetes...
@@ -20,10 +20,10 @@ Most of them are related to Kubernetes...
 
 Anyway I put some of my notes / articles here:
 
-- [Kubernetes with Istio demo](https://ruzickap.gitbook.io/k8s-istio-demo/) ([Presentation](https://slides.com/ruzickap/k8s-istio-demo/))
+- [Kubernetes with Istio demo](https://ruzickap.gitbook.io/k8s-istio-demo/) ([Presentation](https://slides.com/ruzickap/k8s-istio-demo/))
 - [Istio workshop](https://ruzickap.github.io/k8s-istio-workshop/)
-- [Istio webinar](https://ruzickap.github.io/k8s-istio-webinar/) ([Presentation](https://slides.com/ruzickap/k8s-istio-webinar/))
-- [Kubernetes + Harbor](https://ruzickap.github.io/k8s-harbor/) ([Presentation](https://ruzickap.github.io/k8s-harbor-presentation/#/))
+- [Istio webinar](https://ruzickap.github.io/k8s-istio-webinar/) ([Presentation](https://slides.com/ruzickap/k8s-istio-webinar/))
+- [Kubernetes + Harbor](https://ruzickap.github.io/k8s-harbor/) ([Presentation](https://ruzickap.github.io/k8s-harbor-presentation/#/))
 - [Kubernetes + PostgreSQL](https://ruzickap.github.io/k8s-postgresql/)
 - [Kubernetes + Flux + Istio + GitLab + Harbor](https://ruzickap.github.io/k8s-flux-istio-gitlab-harbor/)
 - [Kubernetes + Flagger + Flux + Istio](https://ruzickap.github.io/k8s-flagger-istio-flux/)

--- a/_posts/2020/2020-02-02-check-availability-of-external-links-in-your-web-pages.md
+++ b/_posts/2020/2020-02-02-check-availability-of-external-links-in-your-web-pages.md
@@ -23,7 +23,7 @@ likes to see errors like this:
 Now the page is working fine with all external dependencies because I checked it
 properly - but what about in a few months / years / ... ?
 
-Web pages / images  / videos may disappear from the Internet especially when you
+Web pages / images / videos may disappear from the Internet especially when you
 can not control them and then it's handy from time to time to check your web
 pages if all the external links are still alive.
 
@@ -33,7 +33,7 @@ of your web pages instead of manually clicking the links.
 I would like to share how I'm periodically checking my documents / pages
 using the [GitHub Actions](https://github.com/features/actions).
 
-Here is the GitHub Action I wrote for this purpose: 
+Here is the GitHub Action I wrote for this purpose:
 [My Broken Link Checker](https://github.com/ruzickap/action-my-broken-link-checker)
 
 In short you can simply create a git repository in GitHub and store there the
@@ -89,11 +89,11 @@ This is the screencast where you can see it all in action:
 
 {% include embed/youtube.html id='H6H523TMPXk' %}
 
-This URL checker script is based on [muffet](https://github.com/raviqqe/muffet) 
-and you can set its parameters by changing the `INPUT_CMD_PARAMS` variable.
+This URL checker script is based on [muffet](https://github.com/raviqqe/muffet)
+and you can set its parameters by changing the `INPUT_CMD_PARAMS` variable.
 
 Feel free to look at more details
-here: [https://github.com/ruzickap/action-my-broken-link-checker](https://github.com/ruzickap/action-my-broken-link-checker)
+here: [https://github.com/ruzickap/action-my-broken-link-checker](https://github.com/ruzickap/action-my-broken-link-checker)
 
 I hope this may help you to keep the quality of the web pages by finding the
 external link errors quickly.


### PR DESCRIPTION
Replace U+00A0 (non-breaking space) characters with regular spaces and remove resulting trailing whitespace in six blog posts flagged by Renovate.

## Affected files

- `_posts/2015/2015-12-24-atom-editor-atomio.md`
- `_posts/2017/2017-02-13-provision-windows-server-2016-in-aws-using-ansible-via-cloudformation.md`
- `_posts/2017/2017-07-16-how-to-build-pxe-fedora-26-live-image.md`
- `_posts/2017/2017-10-24-create-windows-image-using-packer-and-ansible-and-then-run-it-in-vagrant-libvirt.md`
- `_posts/2019/2019-10-21-other-posts.md`
- `_posts/2020/2020-02-02-check-availability-of-external-links-in-your-web-pages.md`

Resolves Renovate hidden Unicode character warnings.