### PR TITLE
revert: undo aws-samples digest updates

### DIFF
--- a/_posts/2018/2018-04-20-running-kubernetes-on-appveyor-with-minikube.md
+++ b/_posts/2018/2018-04-20-running-kubernetes-on-appveyor-with-minikube.md
@@ -10,7 +10,7 @@ tags: [kubernetes, automation]
 > Original post from [linux.xvx.cz](https://linux.xvx.cz/2018/04/running-kubernetes-on-appveyor-with.html)
 {: .prompt-info }
 
-When I was playing with Kubernetes I made a lot of [notes](https://multinode-kubernetes-cluster.readthedocs.io)
+When I was playing with Kubernetes I made a lot of [notes](https://multinode-kubernetes-cluster.readthedocs.io/en/latest/)
 on how to do things. Then I realized it may be handy to put those notes to
 Github and let them go through some CI to be sure they are correct.
 

--- a/_posts/2024/2024-05-09-exploit-vulnerability-wordpress-plugin-kali-linux-2.md
+++ b/_posts/2024/2024-05-09-exploit-vulnerability-wordpress-plugin-kali-linux-2.md
@@ -61,11 +61,11 @@ instances:
 # renovate: currentValue=master
 wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/aws-codebuild-samples/00284b828a360aa89ac635a44d84c5a748af03d3/ci_tools/vpc_cloudformation_template.yml
 # renovate:
-wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/amazon-ec2-nice-dcv-samples/25dea48de7c12ddc8dadb0c6dcaee8037451a78f/cfn/KaliLinux-NICE-DCV.yaml
+wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/amazon-ec2-nice-dcv-samples/3cb54467cf4c58bace2f949a704871f9bc0e5af5/cfn/KaliLinux-NICE-DCV.yaml
 # renovate:
-wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/ec2-lamp-server/32ee3bd629cafc844aeb10bd01db2b099b62285e/UbuntuLinux-2204-LAMP-server.yaml
+wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/ec2-lamp-server/c0ec2481d4995771422304b05b7b90bd701052f2/UbuntuLinux-2204-LAMP-server.yaml
 # renovate:
-wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/ec2-lamp-server/32ee3bd629cafc844aeb10bd01db2b099b62285e/AmazonLinux-2023-LAMP-server.yaml
+wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/ec2-lamp-server/c0ec2481d4995771422304b05b7b90bd701052f2/AmazonLinux-2023-LAMP-server.yaml
 ```
 
 Create a new AWS EC2 Key Pair to be used for the EC2 instances:

--- a/_posts/2024/2024-07-07-detect-a-hacker-attacks-eks-vm.md
+++ b/_posts/2024/2024-07-07-detect-a-hacker-attacks-eks-vm.md
@@ -66,9 +66,9 @@ MARIADB_ROOT_PASSWORD=$(openssl rand -base64 12)
 # renovate: currentValue=master
 wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/aws-codebuild-samples/00284b828a360aa89ac635a44d84c5a748af03d3/ci_tools/vpc_cloudformation_template.yml
 # renovate:
-wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/amazon-ec2-nice-dcv-samples/25dea48de7c12ddc8dadb0c6dcaee8037451a78f/cfn/KaliLinux-NICE-DCV.yaml
+wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/amazon-ec2-nice-dcv-samples/9ae94412ff1b4da8eb947516f84a17b11226d174/cfn/KaliLinux-NICE-DCV.yaml
 # renovate:
-wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/ec2-lamp-server/32ee3bd629cafc844aeb10bd01db2b099b62285e/AmazonLinux-2023-LAMP-server.yaml
+wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/ec2-lamp-server/1f3539b5dc2745a974c99a3ed911da00f59534bd/AmazonLinux-2023-LAMP-server.yaml
 
 ## Create a new AWS EC2 Key Pair to be used for the EC2 instances
 aws ec2 create-key-pair --key-name "${AWS_EC2_KEY_PAIR_NAME}" --key-type ed25519 --query "KeyMaterial" --output text > "${TMP_DIR}/${AWS_EC2_KEY_PAIR_NAME}.pem"

--- a/_posts/2025/2025-07-10-ollama-k8s-exploitation.md
+++ b/_posts/2025/2025-07-10-ollama-k8s-exploitation.md
@@ -93,7 +93,7 @@ Launch an AWS EC2 instance with [Kali Linux](https://www.kali.org/) using a
 # renovate: currentValue=master
 wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/aws-codebuild-samples/00284b828a360aa89ac635a44d84c5a748af03d3/ci_tools/vpc_cloudformation_template.yml
 # renovate:
-wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/amazon-ec2-nice-dcv-samples/25dea48de7c12ddc8dadb0c6dcaee8037451a78f/cfn/KaliLinux-NICE-DCV.yaml
+wget --continue -q -P "${TMP_DIR}" https://raw.githubusercontent.com/aws-samples/amazon-ec2-nice-dcv-samples/2a0cddbdf9bf15dce3faaaf33dc499e52db7423c/cfn/KaliLinux-NICE-DCV.yaml
 
 # Create a new AWS EC2 Key Pair to be used for the EC2 instance
 aws ec2 create-key-pair --key-name "${AWS_EC2_KEY_PAIR_NAME}" --key-type ed25519 --query "KeyMaterial" --output text > "${TMP_DIR}/${AWS_EC2_KEY_PAIR_NAME}.pem"


### PR DESCRIPTION
Reverts the following commits:

- de8f8a8912d4ab714a5de0547abd2055d935b13e - chore(deps): update aws-samples/amazon-ec2-nice-dcv-samples digest to 25dea48
- 19c0c15376f65aa86af36cd748d5d6dfe6e4f8b7 - chore(deps): update aws-samples/ec2-lamp-server digest to 32ee3bd