### PR TITLE
fix: pin base image digest in OCI base.name label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN bundle exec jekyll build
 FROM nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:0a5b08a6a5f546f4ed70c1c45815e9be1ba23daf8c5bfdfdd63cc7c341c2e4dd
 
 # renovate: datasource=docker depName=nginxinc/nginx-unprivileged versioning=docker
-LABEL org.opencontainers.image.base.name="nginxinc/nginx-unprivileged:1.31.1-alpine-slim"
+LABEL org.opencontainers.image.base.name="nginxinc/nginx-unprivileged:1.31.1-alpine-slim@sha256:0a5b08a6a5f546f4ed70c1c45815e9be1ba23daf8c5bfdfdd63cc7c341c2e4dd"
 
 COPY --from=build /usr/src/app/_site /usr/share/nginx/html/
 


### PR DESCRIPTION
Add the \`@sha256\` digest (matching the \`FROM\` line) to the
\`org.opencontainers.image.base.name\` LABEL so Renovate's custom regex
manager produces a writable \`digest\` update instead of a failing
\`pinDigest\`.

Without a digest slot in the LABEL, \`docker:pinDigests\` generated a
\`pinDigest\` update that could not be written back, failing the
\`chore/renovate/pin-dependencies\` branch with
\`Error updating branch: update failure\`.

Requires the companion change to the global Renovate config (custom
regex \`matchStrings\` now capture \`currentDigest\`):
ruzickap/my-git-projects#362