### PR TITLE
fix: refine Bedrock guardrail PII handling in OpenWebUI post

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,19 @@ for `shellcheck` syntax validation, so every block must be valid shell.
 - When adding a new tested post, add matching `create:`/`delete:` tasks to
   `mise.toml` **and** an option in `post_tests.yml`.
 
+## Connecting to the EKS / Kubernetes cluster
+
+- To get `kubectl` access to the live EKS cluster, run **`eval "$(mise run a)"`**
+  (`a` is the alias for the `eks-access` task). It sources the base post's env
+  setup (`AWS_REGION`, `CLUSTER_NAME`, …) and runs `aws eks update-kubeconfig`
+  into a throwaway `KUBECONFIG`, so `kubectl` works in the current shell
+  afterwards.
+- This is a **one-time, per-session** action — run it **once** per shell
+  session, then reuse the same session for all `kubectl` commands. Do not
+  re-run it before every command, and do not hand-roll
+  `aws eks update-kubeconfig` yourself.
+- It needs working AWS credentials (`aws sts get-caller-identity` must succeed).
+
 ## Build & lint locally
 
 - Build the site: `bundle exec jekyll build --destination public`

--- a/_posts/2022/2022-11-27-cheapest-amazon-eks.md
+++ b/_posts/2022/2022-11-27-cheapest-amazon-eks.md
@@ -78,7 +78,7 @@ Install the necessary tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 
@@ -252,11 +252,11 @@ _Route53 k8s.mylabs.dev zone_
 
 ## Create Amazon EKS
 
-I will use [eksctl](https://eksctl.io/) to create the Amazon EKS cluster.
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the Amazon EKS cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}
 
-Create the [Amazon EKS](https://aws.amazon.com/eks/) cluster using [eksctl](https://eksctl.io/):
+Create the [Amazon EKS](https://aws.amazon.com/eks/) cluster using [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html):
 
 ```bash
 tee "${TMP_DIR}/${CLUSTER_FQDN}/eksctl-${CLUSTER_NAME}.yml" << EOF
@@ -765,7 +765,7 @@ helm upgrade --install --version "${KUBE_PROMETHEUS_STACK_HELM_CHART_VERSION}" -
 
 Customize the [karpenter](https://karpenter.sh/) default installation by
 upgrading its [Helm chart](https://artifacthub.io/packages/helm/oci-karpenter/karpenter)
-and modifying the [default values](https://github.com/aws/karpenter/blob/v0.31.4/charts/karpenter/values.yaml):
+and modifying the [default values](https://github.com/aws/karpenter-provider-aws/blob/v0.31.4/charts/karpenter/values.yaml):
 
 ```bash
 # renovate: datasource=github-tags depName=aws/karpenter extractVersion=^(?<version>.*)$
@@ -908,7 +908,7 @@ helm upgrade --install --version "${EXTERNAL_DNS_HELM_CHART_VERSION}" --namespac
 ### ingress-nginx
 
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) is an Ingress
-controller for Kubernetes that uses [nginx](https://www.nginx.org/) as a
+controller for Kubernetes that uses [nginx](https://nginx.org/) as a
 reverse proxy and load balancer.
 
 Install the `ingress-nginx` [Helm chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx)

--- a/_posts/2023/2023-08-03-cilium-amazon-eks.md
+++ b/_posts/2023/2023-08-03-cilium-amazon-eks.md
@@ -29,7 +29,7 @@ The Amazon EKS setup aims to meet the following cost-efficiency requirements:
 The Amazon EKS setup should also meet the following security requirements:
 
 - The Amazon EKS control plane must be [encrypted using KMS](https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html)
-- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)
 - Cluster logging to [CloudWatch](https://aws.amazon.com/cloudwatch/) must be
   configured
 - [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
@@ -93,7 +93,7 @@ Install the necessary tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [cilium](https://github.com/cilium/cilium-cli)
 - [helm](https://github.com/helm/helm)
@@ -340,11 +340,11 @@ _KMS key_
 
 ## Create Amazon EKS
 
-I will use [eksctl](https://eksctl.io/) to create the Amazon EKS cluster.
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the Amazon EKS cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}
 
-Create the [Amazon EKS](https://aws.amazon.com/eks/) cluster using [eksctl](https://eksctl.io/):
+Create the [Amazon EKS](https://aws.amazon.com/eks/) cluster using [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html):
 
 ```bash
 tee "${TMP_DIR}/${CLUSTER_FQDN}/eksctl-${CLUSTER_NAME}.yml" << EOF
@@ -1111,7 +1111,7 @@ Endpoint ports:
 
 Customize the [Karpenter](https://karpenter.sh/) default installation by
 upgrading its [Helm chart](https://artifacthub.io/packages/helm/oci-karpenter/karpenter)
-and modifying the [default values](https://github.com/aws/karpenter/blob/v0.31.4/charts/karpenter/values.yaml):
+and modifying the [default values](https://github.com/aws/karpenter-provider-aws/blob/v0.31.4/charts/karpenter/values.yaml):
 
 ```bash
 # renovate: datasource=github-tags depName=aws/karpenter extractVersion=^(?<version>.*)$
@@ -1367,7 +1367,7 @@ helm upgrade --install --version "${EXTERNAL_DNS_HELM_CHART_VERSION}" --namespac
 ### ingress-nginx
 
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) is an Ingress
-controller for Kubernetes that uses [nginx](https://www.nginx.org/) as a
+controller for Kubernetes that uses [nginx](https://nginx.org/) as a
 reverse proxy and load balancer.
 
 Endpoint ports:

--- a/_posts/2023/2023-09-25-secure-cheap-amazon-eks.md
+++ b/_posts/2023/2023-09-25-secure-cheap-amazon-eks.md
@@ -31,7 +31,7 @@ criteria:
 The Amazon EKS setup should also meet the following security requirements:
 
 - The Amazon EKS control plane must be [encrypted using KMS](https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html)
-- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)
 - Cluster logging to [CloudWatch](https://aws.amazon.com/cloudwatch/) must be
   configured
 - [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
@@ -83,7 +83,7 @@ Install the required tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 
@@ -330,7 +330,7 @@ _KMS key_
 
 ## Create Amazon EKS
 
-I will use [eksctl](https://eksctl.io/) to create the [Amazon EKS](https://aws.amazon.com/eks/)
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the [Amazon EKS](https://aws.amazon.com/eks/)
 cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}
@@ -975,7 +975,7 @@ compute resources to handle your cluster's applications.
 
 Customize the [Karpenter](https://karpenter.sh/) default installation by
 upgrading its [Helm chart](https://artifacthub.io/packages/helm/oci-karpenter/karpenter)
-and modifying the [default values](https://github.com/aws/karpenter/blob/v0.31.4/charts/karpenter/values.yaml):
+and modifying the [default values](https://github.com/aws/karpenter-provider-aws/blob/v0.31.4/charts/karpenter/values.yaml):
 
 ```bash
 # renovate: datasource=github-tags depName=aws/karpenter extractVersion=^(?<version>.*)$
@@ -1156,7 +1156,7 @@ kubectl label namespace external-dns pod-security.kubernetes.io/enforce=baseline
 ### ingress-nginx
 
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) is an Ingress
-controller for Kubernetes that uses [nginx](https://www.nginx.org/) as a
+controller for Kubernetes that uses [nginx](https://nginx.org/) as a
 reverse proxy and load balancer.
 
 Install the `ingress-nginx` [Helm chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx)

--- a/_posts/2024/2024-04-27-exploit-vulnerability-wordpress-plugin-kali-linux-1.md
+++ b/_posts/2024/2024-04-27-exploit-vulnerability-wordpress-plugin-kali-linux-1.md
@@ -24,7 +24,7 @@ I will cover the following steps:
 Requirements:
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 

--- a/_posts/2024/2024-05-03-secure-cheap-amazon-eks-with-pod-identities.md
+++ b/_posts/2024/2024-05-03-secure-cheap-amazon-eks-with-pod-identities.md
@@ -31,7 +31,7 @@ criteria:
 The Amazon EKS setup should also meet the following security requirements:
 
 - The Amazon EKS control plane must be [encrypted using KMS](https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html)
-- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)
 - Cluster logging to [CloudWatch](https://aws.amazon.com/cloudwatch/) must be
   configured
 - [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
@@ -86,7 +86,7 @@ Install the required tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 
@@ -707,7 +707,7 @@ _KMS key_
 
 ## Create Amazon EKS
 
-I will use [eksctl](https://eksctl.io/) to create the [Amazon EKS](https://aws.amazon.com/eks/)
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the [Amazon EKS](https://aws.amazon.com/eks/)
 cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}
@@ -1529,7 +1529,7 @@ kubectl label namespace aws-load-balancer-controller pod-security.kubernetes.io/
 ### Ingress NGINX Controller
 
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) is an Ingress
-controller for Kubernetes that uses [nginx](https://www.nginx.org/) as a
+controller for Kubernetes that uses [nginx](https://nginx.org/) as a
 reverse proxy and load balancer.
 
 Install the `ingress-nginx` [Helm chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx)

--- a/_posts/2024/2024-07-07-detect-a-hacker-attacks-eks-vm.md
+++ b/_posts/2024/2024-07-07-detect-a-hacker-attacks-eks-vm.md
@@ -43,7 +43,7 @@ Requirements:
 
 - [AWS CLI](https://builder.aws.com/build/tools)
 - [rain](https://github.com/aws-cloudformation/rain)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 
@@ -77,7 +77,7 @@ chmod 600 "${TMP_DIR}/${AWS_EC2_KEY_PAIR_NAME}.pem"
 
 ### Amazon EKS with Wordpress
 
-Install the Amazon EKS cluster using [eksctl](https://eksctl.io/), run the
+Install the Amazon EKS cluster using [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html), run the
 vulnerable WordPress application, and connect the cluster to Wiz.
 
 ```bash

--- a/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
+++ b/_posts/2024/2024-12-14-secure-cheap-amazon-eks-auto.md
@@ -33,7 +33,7 @@ The Amazon EKS Auto Mode setup should also meet the following security
 requirements:
 
 - The Amazon EKS Auto Mode control plane must be [encrypted using KMS](https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html)
-- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)
 - Cluster logging to [CloudWatch](https://aws.amazon.com/cloudwatch/) must be
   configured
 
@@ -84,7 +84,7 @@ Install the required tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 
@@ -332,7 +332,7 @@ _KMS key_
 
 ## Create Amazon EKS Auto Mode
 
-I will use [eksctl](https://eksctl.io/) to create the [Amazon EKS Auto Mode](https://aws.amazon.com/eks/auto-mode/)
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the [Amazon EKS Auto Mode](https://aws.amazon.com/eks/auto-mode/)
 cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}
@@ -927,7 +927,7 @@ helm upgrade --install --version "${EXTERNAL_DNS_HELM_CHART_VERSION}" --namespac
 ### Ingress NGINX Controller
 
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) is an Ingress
-controller for Kubernetes that uses [nginx](https://www.nginx.org/) as a
+controller for Kubernetes that uses [nginx](https://nginx.org/) as a
 reverse proxy and load balancer.
 
 Install the `ingress-nginx` [Helm chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx)

--- a/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
+++ b/_posts/2025/2025-02-01-eks-auto-cert-manager-velero.md
@@ -35,7 +35,7 @@ Links:
 - An Amazon EKS Auto Mode cluster (as described in
   "[Build secure and cheap Amazon EKS Auto Mode]({% post_url /2024/2024-12-14-secure-cheap-amazon-eks-auto %})")
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [Helm](https://helm.sh)
 - [kubectl](https://github.com/kubernetes/kubectl)
 

--- a/_posts/2025/2025-05-27-mcp-servers-k8s.md
+++ b/_posts/2025/2025-05-27-mcp-servers-k8s.md
@@ -40,7 +40,7 @@ powered by MCP servers and local LLM inference running on your EKS cluster.
 - Amazon EKS Auto Mode cluster (described in
   [Build secure and cheap Amazon EKS Auto Mode]({% post_url /2024/2024-12-14-secure-cheap-amazon-eks-auto %}))
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [Helm](https://helm.sh)
 - [kubectl](https://github.com/kubernetes/kubectl)
 

--- a/_posts/2026/2026-01-13-amazon-eks-grafana-stack.md
+++ b/_posts/2026/2026-01-13-amazon-eks-grafana-stack.md
@@ -27,7 +27,7 @@ The Amazon EKS setup should align with the following criteria:
 - [Karpenter](https://karpenter.sh/) to enable automatic node scaling that
   matches the specific resource requirements of pods
 - The Amazon EKS control plane must be [encrypted using KMS](https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html)
-- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)
 - [EKS cluster logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
   to [CloudWatch](https://aws.amazon.com/cloudwatch/) must be configured
 - [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
@@ -82,7 +82,7 @@ Install the required tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 - [helm](https://github.com/helm/helm)
 
@@ -375,7 +375,7 @@ eval aws cloudformation deploy \
 
 ### Create Amazon EKS
 
-I will use [eksctl](https://eksctl.io/) to create the [Amazon EKS](https://aws.amazon.com/eks/)
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the [Amazon EKS](https://aws.amazon.com/eks/)
 cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}
@@ -1130,7 +1130,7 @@ helm upgrade --install --version "${EXTERNAL_DNS_HELM_CHART_VERSION}" --namespac
 ### Ingress NGINX Controller
 
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) is an Ingress
-controller for Kubernetes that uses [nginx](https://www.nginx.org/) as a
+controller for Kubernetes that uses [nginx](https://nginx.org/) as a
 reverse proxy and load balancer.
 
 Install the `ingress-nginx` [Helm chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx)

--- a/_posts/2026/2026-03-04-amazon-eks-envoy-gateway-argocd.md
+++ b/_posts/2026/2026-03-04-amazon-eks-envoy-gateway-argocd.md
@@ -31,7 +31,7 @@ The Amazon EKS setup should align with the following criteria:
 - [Karpenter](https://karpenter.sh/) to enable automatic node scaling that
   matches the specific resource requirements of pods
 - The Amazon EKS control plane must be [encrypted using KMS](https://docs.aws.amazon.com/eks/latest/userguide/enable-kms.html)
-- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)
+- Worker node [EBS volumes must be encrypted](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)
 - [EKS cluster logging](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)
   to [CloudWatch](https://aws.amazon.com/cloudwatch/) must be configured
 - [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
@@ -97,7 +97,7 @@ Install the required tools:
 <!-- prettier-ignore-end -->
 
 - [AWS CLI](https://builder.aws.com/build/tools)
-- [eksctl](https://eksctl.io/)
+- [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html)
 - [kubectl](https://github.com/kubernetes/kubectl)
 
 ```bash
@@ -392,7 +392,7 @@ eval aws cloudformation deploy --stack-name "${CLUSTER_NAME}-karpenter" \
 
 ### Create Amazon EKS
 
-I will use [eksctl](https://eksctl.io/) to create the
+I will use [eksctl](https://docs.aws.amazon.com/eks/latest/eksctl/what-is-eksctl.html) to create the
 [Amazon EKS](https://aws.amazon.com/eks/) cluster.
 
 ![eksctl](https://raw.githubusercontent.com/weaveworks/eksctl/2b1ec6223c4e7cb8103c08162e6de8ced47376f9/userdocs/src/img/eksctl.png){:width="700"}

--- a/_posts/2026/2026-05-26-openwebui-eks-bedrock-opentofu.md
+++ b/_posts/2026/2026-05-26-openwebui-eks-bedrock-opentofu.md
@@ -389,17 +389,13 @@ provider "helm" {
 locals {
   cluster_name = split(".", var.cluster_fqdn)[0]
   base_domain  = join(".", slice(split(".", var.cluster_fqdn), 1, length(split(".", var.cluster_fqdn))))
-  pii_block = [
-    "PASSWORD", "CREDIT_DEBIT_CARD_NUMBER", "PIN",
-    "INTERNATIONAL_BANK_ACCOUNT_NUMBER", "SWIFT_CODE",
-    "AWS_ACCESS_KEY", "AWS_SECRET_KEY",
-    "US_SOCIAL_SECURITY_NUMBER", "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER",
-    "US_BANK_ACCOUNT_NUMBER", "US_BANK_ROUTING_NUMBER",
-    "CA_HEALTH_NUMBER", "CA_SOCIAL_INSURANCE_NUMBER",
-    "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER", "UK_NATIONAL_INSURANCE_NUMBER",
-    "UK_NATIONAL_HEALTH_SERVICE_NUMBER",
+  pii_anonymize = [
+    "PHONE", "EMAIL", "ADDRESS", "PASSWORD", "DRIVER_ID", "LICENSE_PLATE", "VEHICLE_IDENTIFICATION_NUMBER",
+    "CREDIT_DEBIT_CARD_NUMBER", "PIN", "INTERNATIONAL_BANK_ACCOUNT_NUMBER", "SWIFT_CODE", "MAC_ADDRESS",
+    "AWS_ACCESS_KEY", "AWS_SECRET_KEY", "US_SOCIAL_SECURITY_NUMBER", "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER",
+    "US_BANK_ACCOUNT_NUMBER", "US_BANK_ROUTING_NUMBER", "CA_HEALTH_NUMBER", "CA_SOCIAL_INSURANCE_NUMBER",
+    "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER", "UK_NATIONAL_INSURANCE_NUMBER", "UK_NATIONAL_HEALTH_SERVICE_NUMBER",
   ]
-  pii_anonymize = ["PHONE", "EMAIL", "ADDRESS", "DRIVER_ID", "LICENSE_PLATE", "VEHICLE_IDENTIFICATION_NUMBER", "MAC_ADDRESS"]
   # [rule_no, action, from_port, to_port, protocol]
   nacl_ingress = [
     [89, "deny", 22, 22, "tcp"],
@@ -560,33 +556,26 @@ resource "aws_bedrock_guardrail" "ai_safety" {
   blocked_input_messaging   = "Input contains blocked PII"
   blocked_outputs_messaging = "Output contains blocked PII"
 
-  content_policy_config {
-    filters_config {
-      type            = "SEXUAL"
-      input_strength  = "HIGH"
-      output_strength = "HIGH"
-    }
-    filters_config {
-      type            = "PROMPT_ATTACK"
-      input_strength  = "HIGH"
-      output_strength = "NONE"
-    }
-  }
-
   sensitive_information_policy_config {
-    dynamic "pii_entities_config" {
-      for_each = local.pii_block
-      content {
-        type   = pii_entities_config.value
-        action = "BLOCK"
-      }
-    }
     dynamic "pii_entities_config" {
       for_each = local.pii_anonymize
       content {
         type   = pii_entities_config.value
         action = "ANONYMIZE"
       }
+    }
+  }
+
+  content_policy_config {
+    filters_config {
+      type            = "PROMPT_ATTACK"
+      input_strength  = "HIGH"
+      output_strength = "NONE"
+    }
+    filters_config {
+      type            = "SEXUAL"
+      input_strength  = "HIGH"
+      output_strength = "HIGH"
     }
   }
 }
@@ -1750,6 +1739,9 @@ resource "helm_release" "litellm" {
           litellm_params:
             model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
             aws_region_name: ${data.aws_region.current.region}
+            # Claude on Bedrock rejects temperature+top_p together.
+            # Collmbo sends temperature, so drop top_p.
+            additional_drop_params: ["top_p"]
             guardrailConfig:
               guardrailIdentifier: ${aws_bedrock_guardrail.ai_safety.guardrail_arn}
               guardrailVersion: "DRAFT"


### PR DESCRIPTION
## What

Refines the Amazon Bedrock guardrail configuration and LiteLLM model
params in the OpenWebUI EKS Bedrock OpenTofu post.

## Changes

- **PII handling**: Anonymize the full set of PII entities instead of
  blocking a subset (`pii_block` removed, consolidated into
  `pii_anonymize`).
- **Content policy**: Reorder guardrail filters (`PROMPT_ATTACK` before
  `SEXUAL`).
- **LiteLLM**: Add `additional_drop_params: ["top_p"]` for Claude on
  Bedrock to avoid the `temperature` + `top_p` conflict, since Collmbo
  sends `temperature`.

## Why

Claude on Bedrock rejects `temperature` and `top_p` together, and the
guardrail PII policy is simpler and more consistent when anonymizing
rather than mixing block/anonymize actions.