### PR TITLE
fix: prevent litellm helm release failure on schema migration

### DIFF
--- a/_posts/2026/2026-05-26-openwebui-eks-bedrock-opentofu.md
+++ b/_posts/2026/2026-05-26-openwebui-eks-bedrock-opentofu.md
@@ -1730,9 +1730,15 @@ resource "helm_release" "litellm" {
       auth:
         password: ${random_password.litellm_master_key.result}
         postgres-password: ${random_password.litellm_master_key.result}
-    disableSchemaUpdate: false
+    # The chart's default migration Job (Prisma) OOMKills with the chart's
+    # unset limits; its post-migration sanity check needs ~3Gi to succeed.
     migrationJob:
-      enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 3Gi
+        limits:
+          memory: 3Gi
     proxy_config:
       model_list:
         - model_name: us.anthropic.claude-haiku-4-5-20251001-v1:0

--- a/_posts/2026/2026-06-17-slack-bot-bedrock-confluence.md
+++ b/_posts/2026/2026-06-17-slack-bot-bedrock-confluence.md
@@ -710,9 +710,15 @@ resource "helm_release" "litellm_kb" {
       auth:
         password: ${random_password.litellm_kb_master_key.result}
         postgres-password: ${random_password.litellm_kb_master_key.result}
-    disableSchemaUpdate: false
+    # The chart's default migration Job (Prisma) OOMKills with the chart's
+    # unset limits; its post-migration sanity check needs ~3Gi to succeed.
     migrationJob:
-      enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 3Gi
+        limits:
+          memory: 3Gi
     proxy_config:
       model_list:
         # Always-on RAG model: every call queries the Bedrock Knowledge Base


### PR DESCRIPTION
## Problem

The `litellm` and `litellm-kb` `helm_release`s disabled the chart's default
migration Job (`migrationJob.enabled: false`) and relied on the proxy's
in-process Prisma schema push (`disableSchemaUpdate: false`).

On the slower `litellm-database` 1.89.2 image the proxy creates ~80 tables on
an empty DB at boot and loses the race against its startup probe
(`failureThreshold 30 × 10s = 5 min`), especially after the cold ~600MB image
pull. The pod is killed/restarted and the Helm `wait` times out:

```
Error: Helm release error
context deadline exceeded
```

Because the install fails, the `post-install` vector-store registration hook
never runs, so RAG silently returns no Confluence context.

## Fix

Re-enable the chart's default `pre-install,pre-upgrade` migration Job so the
schema exists **before** the proxy starts. The chart's migration Job ships with
no resource limits, and the Prisma migration peaks above 2Gi during its
post-migration sanity check, so it OOMKills by default. Give the Job a 3Gi
request/limit.

Verified on a live EKS cluster (memory sweep of the migration Job):

| `limits.memory` | Result |
|---|---|
| 512Mi | OOMKilled immediately |
| 1Gi | OOMKilled on startup |
| 2Gi | migrations apply, but OOMKills on sanity check (flaky) |
| **3Gi** | **completes, 0 restarts; `STATUS: deployed`; RAG works** |

Karpenter scales a node up for the 3Gi request and back down once the Job
completes.

Applied to both the base post (`litellm`) and the Slack-bot post
(`litellm-kb`), which share the same pattern.