### PR TITLE
ci: update MegaLinter configuration

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -71,6 +71,9 @@ REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed
 
+# Lychee arguments: set workspace root for root-relative links
+SPELL_LYCHEE_ARGUMENTS: --root-dir /github/workspace
+
 # Lychee (link checker) - exclude projects tab from link validation
 SPELL_LYCHEE_FILTER_REGEX_EXCLUDE: _tabs/projects.md
 

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -6,7 +6,7 @@
 # and in individual linters documentation
 
 # keep-sorted start newline_separated=yes
-# Allow zizmor (GitHub Actions security scanner) to access GitHub token for API calls
+# Allow zizmor (GitHub Actions security scanner) to access GitHub token
 ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
   - GITHUB_TOKEN
 
@@ -22,21 +22,14 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 # Disable linters
 DISABLE_LINTERS:
   - COPYPASTE_JSCPD
-  - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
-  - REPOSITORY_GITLEAKS # Deprecated in favor of Betterleaks (REPOSITORY_BETTERLEAKS)
   - REPOSITORY_KINGFISHER # Secret detection with too many false positives
-  - REPOSITORY_OSV_SCANNER # No package lockfiles in this Jekyll blog repository
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
-  - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
-
-# Disable email reporting
-EMAIL_REPORTER: false
 
 # Fail the build if a required linter is missing from the Docker flavor
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 
 # Exclude CHANGELOG.md from all linting
-FILTER_REGEX_EXCLUDE: CHANGELOG.md
+FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Allow formatters to report errors
 FORMATTERS_DISABLE_ERRORS: false
@@ -47,11 +40,17 @@ JSON_JSONLINT_ARGUMENTS: --comments
 # Exclude devcontainer.json from JSON linting (VS Code extension format)
 JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 
+# Use rumdl as the default Markdown style (faster Rust-based alternative)
+MARKDOWN_DEFAULT_STYLE: rumdl
+
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
-MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
+MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false
+
+# Use ruff as the default Python style (faster Rust-based alternative)
+PYTHON_DEFAULT_STYLE: ruff
 
 # Don't create a report output folder (using CI artifacts instead)
 REPORT_OUTPUT_FOLDER: none
@@ -63,17 +62,14 @@ REPOSITORY_CHECKOV_ARGUMENTS: --quiet
 # --ignore-rule-ids DS162092,DS137138: ignore specific rules:
 #   - DS162092: "Do not leave debug code in production"
 #   - DS137138: "Insecure URL" (for HTTP links that are intentional)
-REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-globs CHANGELOG.md --ignore-rule-ids DS162092,DS137138
+REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-rule-ids DS162092,DS137138
 
-# Disable automatic forwarding of EXCLUDED_DIRECTORIES to DevSkim
-# (conflicts with --ignore-globs in REPOSITORY_DEVSKIM_ARGUMENTS)
-REPOSITORY_DEVSKIM_FORWARD_EXCLUDED_DIRECTORIES: false
+# Kingfisher (secret scanner) - exclude .git to avoid false positives on Git
+# metadata files, such as refs that match token patterns
+REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git
 
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed
-
-# Lychee arguments: set workspace root and enable verbose output
-SPELL_LYCHEE_ARGUMENTS: --root-dir /github/workspace --verbose
 
 # Lychee (link checker) - exclude projects tab from link validation
 SPELL_LYCHEE_FILTER_REGEX_EXCLUDE: _tabs/projects.md

--- a/_posts/2009/2009-03-17-how-to-store-google-maps-or-any-other-page-as-jpg-or-png.md
+++ b/_posts/2009/2009-03-17-how-to-store-google-maps-or-any-other-page-as-jpg-or-png.md
@@ -26,7 +26,9 @@ I found a solution in KDE:
 
 1. Install Firefox add-on called Abduction! It will allow you to save pages or
    part of the page as image (File -> Save Page As Image...)
+
 2. Run Firefox and choose your place in the map.
+
 3. Press ALT + F3 -> Advanced -> Special Windows Settings...
 
    ![Advanced Windows Settings - KDE](/assets/img/posts/2009/2009-03-17-how-to-store-google-maps-or-any-other-page-as-jpg-or-png/advanced_settings.avif)

--- a/_posts/2012/2012-01-28-another-openwrt-configuration.md
+++ b/_posts/2012/2012-01-28-another-openwrt-configuration.md
@@ -14,11 +14,10 @@ I would like to describe another [OpenWrt](https://openwrt.org/) configuration.
 It's going to be just a few examples on how to configure the latest available
 OpenWrt firmware [Backfire 10.03.1](https://archive.openwrt.org/backfire/10.03.1/).
 
-I'm going to use [TP-Link
-TL-WR1043ND](https://www.tp-link.com/en/home-networking/wifi-router/tl-wr1043nd/) wifi
-router with a small 64MB USB stick `/dev/sda1` containing an ext2 partition. I
-plan
-to have some stats on the USB stick and simple html pages as well.
+I'm going to use
+[TP-Link TL-WR1043ND](https://www.tp-link.com/en/home-networking/wifi-router/tl-wr1043nd/)
+wifi router with a small 64MB USB stick `/dev/sda1` containing an ext2 partition.
+I plan to have some stats on the USB stick and simple html pages as well.
 
 <!-- rumdl-disable MD013 -->
 After flashing the original firmware with [openwrt-ar71xx-tl-wr1043nd-v1-squashfs-factory.bin](https://archive.openwrt.org/backfire/10.03.1/ar71xx/openwrt-ar71xx-tl-wr1043nd-v1-squashfs-factory.bin)

--- a/_posts/2013/2013-06-24-tl-wr1043nd-wifi-router-with-camera-and-theromometers.md
+++ b/_posts/2013/2013-06-24-tl-wr1043nd-wifi-router-with-camera-and-theromometers.md
@@ -10,9 +10,9 @@ tags: [tp-link, router, monitoring]
 > Original post from [linux.xvx.cz](https://linux.xvx.cz/2013/06/tl-wr1043nd-wifi-router-with-camera-and.html)
 {: .prompt-info }
 
-Here are a few photos of my 2-year-old [TP-Link
-TL-WR1043ND](https://www.tp-link.com/en/home-networking/wifi-router/tl-wr1043nd/) wifi
-router. It was getting some pictures from camera using
+Here are a few photos of my 2-year-old
+[TP-Link TL-WR1043ND](https://www.tp-link.com/en/home-networking/wifi-router/tl-wr1043nd/)
+wifi router. It was getting some pictures from camera using
 [fswebcam](https://web.archive.org/web/20130621044049/http://www.firestorm.cx/fswebcam/) and measuring internal/external
 temperature using [digitemp](https://www.digitemp.com/).
 

--- a/_posts/2013/2013-08-03-tp-link-tl-wr1043nd-and-openwrt-1209-with-two-ssids-multissid-private-and-guest.md
+++ b/_posts/2013/2013-08-03-tp-link-tl-wr1043nd-and-openwrt-1209-with-two-ssids-multissid-private-and-guest.md
@@ -14,9 +14,9 @@ I decided to change my home network to match the following "network diagram":
 
 ![OpenWrt multi-SSID network diagram](https://raw.githubusercontent.com/ruzickap/linux.xvx.cz/refs/heads/gh-pages/pics/openwrt/wifi_openwrt2.svg)
 
-The core part of the design is [TP-Link
-TL-WR1043ND](https://www.tp-link.com/en/home-networking/wifi-router/tl-wr1043nd/) wifi
-router running [OpenWrt](https://openwrt.org/) with a small 16GB USB stick
+The core part of the design is
+[TP-Link TL-WR1043ND](https://www.tp-link.com/en/home-networking/wifi-router/tl-wr1043nd/)
+wifi router running [OpenWrt](https://openwrt.org/) with a small 16GB USB stick
 `/dev/sda1` containing ext3 partition with OpenWrt configuration + swap.
 
 There is also a 16GB USB stick and 2 thermometers connected using USB Serial

--- a/_posts/2014/2014-04-09-turris-the-open-enterprise-wi-fi-router.md
+++ b/_posts/2014/2014-04-09-turris-the-open-enterprise-wi-fi-router.md
@@ -27,8 +27,9 @@ hardware/software platform.
 ## Hardware
 
 The details about the hardware including design and manufacture data is
-published under the terms of the [CERN Open Hardware
-License](https://web.archive.org/web/20140510092123/http://www.ohwr.org/projects/cernohl/wiki) and can be found here:
+published under the terms of the
+[CERN Open Hardware License](https://web.archive.org/web/20140510092123/http://www.ohwr.org/projects/cernohl/wiki)
+and can be found here:
 [Hardware documentation](https://web.archive.org/web/20160321003446/https://www.turris.cz/en/hardware-documentation).
 These details are really nice, because everybody can look at it and improve...
 

--- a/_posts/2014/2014-04-22-turris-openwrt-and-thermometers.md
+++ b/_posts/2014/2014-04-22-turris-openwrt-and-thermometers.md
@@ -17,7 +17,8 @@ I would like to put here some notes about the thermometers in
 
 Turris has its own thermometers which are monitoring the temperature of CPU and
 board. This how-to expects the previous lighttpd configuration described in my
-previous post "[Turris - OpenWrt configuration]({% post_url /2014/2014-04-22-turris-openwrt-and-thermometers %})".
+previous post
+"[Turris - OpenWrt configuration]({% post_url /2014/2014-04-22-turris-openwrt-and-thermometers %})".
 Here is how you can create graphs from the data using [RRDtool](https://oss.oetiker.ch/rrdtool/).
 
 ```bash

--- a/_posts/2014/2014-04-22-turris-openwrt-and-thermometers.md
+++ b/_posts/2014/2014-04-22-turris-openwrt-and-thermometers.md
@@ -136,12 +136,12 @@ values, so you need to read them a few times.
 ```bash
 mkdir -p /data/mydigitemp /www3/mydigitemp
 #The graphs can be accessed: http://192.168.1.1/myadmin/mydigitemp
-ln -s /www3/mydigitemp  /www3/myadmin/mydigitemp
+ln -s /www3/mydigitemp /www3/myadmin/mydigitemp
 
 #Create RRDtool database to store the values every 10 minutes (600 seconds) for 10 years (525600 * 600 seconds)
 rrdtool create /data/mydigitemp/mydigitemp.rrd --step 600 \
-DS:temp0:GAUGE:1000:-273:5000 DS:temp1:GAUGE:1000:-273:5000 RRA:AVERAGE:0.5:1:525600 \
-RRA:MIN:0.5:1:525600 RRA:MAX:0.5:1:525600
+  DS:temp0:GAUGE:1000:-273:5000 DS:temp1:GAUGE:1000:-273:5000 RRA:AVERAGE:0.5:1:525600 \
+  RRA:MIN:0.5:1:525600 RRA:MAX:0.5:1:525600
 
 #Script getting the data from thermometers
 cat > /data/mydigitemp/mydigitemp.sh << \EOF

--- a/_posts/2014/2014-05-08-turris-openwrt-and-guest-access.md
+++ b/_posts/2014/2014-05-08-turris-openwrt-and-guest-access.md
@@ -10,9 +10,10 @@ tags: [turris, router, wifi, hotspot]
 > Original post from [linux.xvx.cz](https://linux.xvx.cz/2014/05/turris-openwrt-and-guest-access.html)
 {: .prompt-info }
 
-In my previous blog post "[Turris - OpenWrt configuration]({% post_url /2014/2014-04-16-turris-openwrt-configuration %})"
-I described how to configure the [Turris](https://www.turris.cz/en/) router for my
-[home network](https://raw.githubusercontent.com/ruzickap/linux.xvx.cz/refs/heads/gh-pages/pics/openwrt/wifi_openwrt4.svg).
+In my previous blog post
+"[Turris - OpenWrt configuration]({% post_url /2014/2014-04-16-turris-openwrt-configuration %})"
+I described how to configure the [Turris](https://www.turris.cz/en/) router for
+my [home network](https://raw.githubusercontent.com/ruzickap/linux.xvx.cz/refs/heads/gh-pages/pics/openwrt/wifi_openwrt4.svg).
 I decided to extend the configuration and create the Guest WiFi for other people
 who want to access the "Internet". In my solution I'm using the
 [nodogsplash](https://web.archive.org/web/20140210131130/http://kokoro.ucsd.edu/nodogsplash/) captive portal solution which

--- a/_posts/2022/2022-01-06-monitor-your-raspberry-pi-using-grafana-cloud.md
+++ b/_posts/2022/2022-01-06-monitor-your-raspberry-pi-using-grafana-cloud.md
@@ -25,6 +25,7 @@ Here are the steps to configure your Raspberry Pi to use Grafana Cloud:
 
 - Go to [Grafana Cloud](https://grafana.com/products/cloud/) and create a new
   account.
+
 - Select your "Team URL" and region:
 
   ![Grafana Cloud Team URL](/assets/img/posts/2022/2022-01-06-monitor-your-raspberry-pi-using-grafana-cloud/grafana-cloud-team-url.avif)
@@ -35,6 +36,7 @@ Here are the steps to configure your Raspberry Pi to use Grafana Cloud:
 
 - I left the "Debian - based" as a default and changed the "Architecture" to
   "Armv7"
+
 - Copy the content from the Grafana Agent field and paste it to your shell
   connected to RPi
 


### PR DESCRIPTION
## Summary

- select rumdl and ruff as the default MegaLinter styles
- simplify obsolete linter exclusions and DevSkim/Lychee options
- tighten exclusion regexes and exclude Git metadata from Kingfisher

## Validation

- pre-commit hooks
- `yamllint .mega-linter.yml` (existing warnings only)