### PR TITLE
ci: use Bun to run Prettier

### DIFF
--- a/.github/workflows/generate-projects.yml
+++ b/.github/workflows/generate-projects.yml
@@ -20,12 +20,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Generate _tabs/projects.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install prettier
           scripts/generate-projects.sh _tabs/projects.md
 
       - name: Create Pull Request

--- a/scripts/generate-projects.sh
+++ b/scripts/generate-projects.sh
@@ -94,4 +94,4 @@ ${GITHUB_REPOSITORY_CI_CD_STATUS}
 EOF
 done <<< "$(gh repo list --visibility public --json defaultBranchRef,description,homepageUrl,isArchived,nameWithOwner,repositoryTopics,url --jq 'sort_by(.nameWithOwner).[]' awsugcz | jq -c && gh repo list --visibility public --topic public --limit 100 --json defaultBranchRef,description,homepageUrl,isArchived,nameWithOwner,repositoryTopics,url --jq 'sort_by(.nameWithOwner).[]' ruzickap | jq -c)"
 
-npx prettier -w --parser markdown --prose-wrap always --print-width 80 "${DESTINATION_FILE}"
+bunx prettier -w --parser markdown --prose-wrap always --print-width 80 "${DESTINATION_FILE}"


### PR DESCRIPTION
## Summary

- set up Bun with a SHA-pinned GitHub Action
- run Prettier through `bunx` when generating the projects page
- remove the Homebrew Prettier installation from the workflow

## Testing

- pre-commit hooks